### PR TITLE
Automatically make a test hist importable

### DIFF
--- a/run_galaxy_workflow_tests.sh
+++ b/run_galaxy_workflow_tests.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 : ${PLANEMO_OPTIONS:=""}  # e.g. PLANEMO_OPTIONS="--verbose"
 
+# Ensure we can find this history later.
+nonce=$(date +%s)
+history_name="$1 $nonce"
+
 # Run test.
 planemo  $PLANEMO_OPTIONS test \
+	--history_name "$history_name"
 	--galaxy_url "https://usegalaxy.eu" \
 	--galaxy_user_key "$GALAXY_USER_KEY" --no_shed_install \
 	--engine external_galaxy \

--- a/run_galaxy_workflow_tests.sh
+++ b/run_galaxy_workflow_tests.sh
@@ -6,9 +6,17 @@ nonce=$(date +%s)
 history_name="$1 $nonce"
 
 # Run test.
-planemo  $PLANEMO_OPTIONS test \
-	--history_name "$history_name"
+set +e # Do not die if planemo returns non-zero
+planemo $PLANEMO_OPTIONS test \
+	--history_name "$history_name" \
 	--galaxy_url "https://usegalaxy.eu" \
 	--galaxy_user_key "$GALAXY_USER_KEY" --no_shed_install \
 	--engine external_galaxy \
-	"$1"
+	"$1";
+planemo_exit_code=$?
+set -e
+
+history_id=$(parsec histories get_histories --name 'CWL Target History' | jq -r .[0].id)
+history_slug=$(parsec histories update_history --importable $history_id | jq -r .username_and_slug)
+echo "History published at https://usegalaxy.eu/$history_slug"
+exit $planemo_exit_code


### PR DESCRIPTION
Will allow devs to debug more easily. This just finds the history of the same name and then uses parsec to publish it. Only makes it importable, not published so it won't clutter up the 'published histories' section.

I've switched jenkins to use the master branch of planemo.