### PR TITLE
add imaging workflow

### DIFF
--- a/imaging/imaging_many_jobs-test.yml
+++ b/imaging/imaging_many_jobs-test.yml
@@ -1,0 +1,17 @@
+---
+- doc: Test an imaging workflow with 4000 jobs
+  job:
+    images.zip:
+      class: File
+      location: https://zenodo.org/record/3360236/files/data.zip
+      filetype: zip
+    rules:
+      class: File
+      location: rules.tabular
+      filetype: tabular
+  outputs:
+    outputs_collapsed:
+      asserts:
+        has_line:
+          line: '33421.40648011782	679	29.994753456131555'
+        has_n_columns: 3

--- a/imaging/imaging_many_jobs-test.yml
+++ b/imaging/imaging_many_jobs-test.yml
@@ -14,4 +14,5 @@
       asserts:
         has_line:
           line: '33421.40648011782	679	29.994753456131555'
-        has_n_columns: 3
+        ## not yet implemented
+        ##has_n_columns: 4963

--- a/imaging/imaging_many_jobs.ga
+++ b/imaging/imaging_many_jobs.ga
@@ -1,0 +1,605 @@
+{
+   "uuid":"860df131-dbe4-40ad-93bb-a52bba5595e7",
+   "tags":[
+
+   ],
+   "format-version":"0.1",
+   "name":"Analyze screen from zip archive",
+   "version":1,
+   "steps":{
+      "0":{
+         "tool_id":null,
+         "tool_version":null,
+         "outputs":[
+
+         ],
+         "workflow_outputs":[
+         ],
+         "input_connections":{
+
+         },
+         "tool_state":"{}",
+         "id":0,
+         "uuid":"5ed284d2-e9f7-4576-a30b-d5af37e5ea5d",
+         "errors":null,
+         "name":"Input dataset",
+         "label":"images.zip",
+         "inputs":[
+            {
+              "description": "Images in ZIP format", 
+              "name": "images.zip"
+            }
+         ],
+         "position":{
+            "top":200,
+            "left":200
+         },
+         "annotation":"",
+         "content_id":null,
+         "type":"data_input"
+      },
+      "1":{
+         "tool_id":null,
+         "tool_version":null,
+         "outputs":[
+
+         ],
+         "workflow_outputs":[
+         ],
+         "input_connections":{
+
+         },
+         "tool_state":"{}",
+         "id":1,
+         "uuid":"c4cdc22b-48d0-4db2-ae15-9f35d747e2eb",
+         "errors":null,
+         "name":"Input dataset",
+         "label":"rules",
+         "inputs":[
+            {
+              "description": "Rules file", 
+              "name": "rules"
+            }
+         ],
+         "position":{
+            "top":452.8833312988281,
+            "left":464.3833312988281
+         },
+         "annotation":"",
+         "content_id":null,
+         "type":"data_input"
+      },
+      "2":{
+         "tool_id":"toolshed.g2.bx.psu.edu/repos/imgteam/unzip/unzip/0.2",
+         "tool_version":"0.2",
+         "outputs":[
+            {
+               "type":"input",
+               "name":"unzipped"
+            }
+         ],
+         "workflow_outputs":[
+         ],
+         "input_connections":{
+            "input_file":{
+               "output_name":"output",
+               "id":0
+            }
+         },
+         "tool_state":"{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"extract_options\": \"{\\\"__current_case__\\\": 0, \\\"extract_all\\\": \\\"True\\\"}\", \"input_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+         "id":2,
+         "tool_shed_repository":{
+            "owner":"imgteam",
+            "changeset_revision":"38eec75fbe9b",
+            "name":"unzip",
+            "tool_shed":"toolshed.g2.bx.psu.edu"
+         },
+         "uuid":"f0a50ae5-7f79-41ab-9626-a584aa7f2a1c",
+         "errors":null,
+         "name":"Unzip",
+         "post_job_actions":{
+
+         },
+         "label":null,
+         "inputs":[
+            {
+               "name":"input_file",
+               "description":"runtime parameter for tool Unzip"
+            }
+         ],
+         "position":{
+            "top":268,
+            "left":434.0000305175781
+         },
+         "annotation":"",
+         "content_id":"toolshed.g2.bx.psu.edu/repos/imgteam/unzip/unzip/0.2",
+         "type":"tool"
+      },
+      "3":{
+         "tool_id":"7ddb0fe3ba37c4cf",
+         "inputs":[
+
+         ],
+         "outputs":[
+
+         ],
+         "subworkflow":{
+            "uuid":"4a5c1b78-c7da-46b6-8836-9d645a7df9af",
+            "tags":"",
+            "format-version":"0.1",
+            "name":"feature_extraction",
+            "steps":{
+               "0":{
+                  "tool_id":null,
+                  "tool_version":null,
+                  "outputs":[
+
+                  ],
+                  "workflow_outputs":[
+                     {
+                        "output_name":"output",
+                        "uuid":"e15c31d2-969c-4c14-a646-d7317f23e614",
+                        "label":null
+                     }
+                  ],
+                  "input_connections":{
+
+                  },
+                  "tool_state":"{}",
+                  "id":0,
+                  "uuid":"8465a62f-a0c8-478a-82d9-70282b5d784b",
+                  "errors":null,
+                  "name":"Input dataset",
+                  "label":"input image",
+                  "inputs":[
+
+                  ],
+                  "position":{
+                     "top":459.1875,
+                     "left":154
+                  },
+                  "annotation":"",
+                  "content_id":null,
+                  "type":"data_input"
+               },
+               "1":{
+                  "tool_id":null,
+                  "tool_version":null,
+                  "outputs":[
+
+                  ],
+                  "workflow_outputs":[
+                     {
+                        "output_name":"output",
+                        "uuid":"d9dc432a-a990-4111-9941-269290457b00",
+                        "label":null
+                     }
+                  ],
+                  "input_connections":{
+
+                  },
+                  "tool_state":"{}",
+                  "id":1,
+                  "uuid":"1762926f-a1d3-47d8-91c1-9c6f2f051de0",
+                  "errors":null,
+                  "name":"Input dataset",
+                  "label":"filter rules",
+                  "inputs":[
+
+                  ],
+                  "position":{
+                     "top":558.5,
+                     "left":160
+                  },
+                  "annotation":"",
+                  "content_id":null,
+                  "type":"data_input"
+               },
+               "2":{
+                  "tool_id":"toolshed.g2.bx.psu.edu/repos/imgteam/2d_simple_filter/ip_filter_standard/0.0.3",
+                  "tool_version":"0.0.3",
+                  "outputs":[
+                     {
+                        "type":"tiff",
+                        "name":"output"
+                     }
+                  ],
+                  "workflow_outputs":[
+
+                  ],
+                  "input_connections":{
+                     "input":{
+                        "output_name":"output",
+                        "id":0
+                     }
+                  },
+                  "tool_state":"{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"radius\": \"\\\"3\\\"\", \"filter_type\": \"\\\"gaussian\\\"\", \"__page__\": null}",
+                  "id":2,
+                  "tool_shed_repository":{
+                     "owner":"imgteam",
+                     "changeset_revision":"dba87c4b32d3",
+                     "name":"2d_simple_filter",
+                     "tool_shed":"toolshed.g2.bx.psu.edu"
+                  },
+                  "uuid":"a1c73eda-c075-4b5f-8000-9d47b4e46e10",
+                  "errors":null,
+                  "name":"Filter Image",
+                  "post_job_actions":{
+                     "HideDatasetActionoutput":{
+                        "output_name":"output",
+                        "action_type":"HideDatasetAction",
+                        "action_arguments":{
+
+                        }
+                     }
+                  },
+                  "label":null,
+                  "inputs":[
+                     {
+                        "name":"input",
+                        "description":"runtime parameter for tool Filter Image"
+                     }
+                  ],
+                  "position":{
+                     "top":195,
+                     "left":325.5
+                  },
+                  "annotation":"",
+                  "content_id":"toolshed.g2.bx.psu.edu/repos/imgteam/2d_simple_filter/ip_filter_standard/0.0.3",
+                  "type":"tool"
+               },
+               "3":{
+                  "tool_id":"toolshed.g2.bx.psu.edu/repos/imgteam/2d_auto_threshold/ip_threshold/0.0.3",
+                  "tool_version":"0.0.3",
+                  "outputs":[
+                     {
+                        "type":"tiff",
+                        "name":"output"
+                     }
+                  ],
+                  "workflow_outputs":[
+
+                  ],
+                  "input_connections":{
+                     "input":{
+                        "output_name":"output",
+                        "id":2
+                     }
+                  },
+                  "tool_state":"{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"thresh_type\": \"\\\"otsu\\\"\", \"dark_background\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"__page__\": null}",
+                  "id":3,
+                  "tool_shed_repository":{
+                     "owner":"imgteam",
+                     "changeset_revision":"d4da97f51700",
+                     "name":"2d_auto_threshold",
+                     "tool_shed":"toolshed.g2.bx.psu.edu"
+                  },
+                  "uuid":"9a3428a3-749a-4e43-8e26-b1d393675f63",
+                  "errors":null,
+                  "name":"Auto Threshold",
+                  "post_job_actions":{
+                     "HideDatasetActionoutput":{
+                        "output_name":"output",
+                        "action_type":"HideDatasetAction",
+                        "action_arguments":{
+
+                        }
+                     }
+                  },
+                  "label":null,
+                  "inputs":[
+                     {
+                        "name":"input",
+                        "description":"runtime parameter for tool Auto Threshold"
+                     }
+                  ],
+                  "position":{
+                     "top":195,
+                     "left":565.5
+                  },
+                  "annotation":"",
+                  "content_id":"toolshed.g2.bx.psu.edu/repos/imgteam/2d_auto_threshold/ip_threshold/0.0.3",
+                  "type":"tool"
+               },
+               "4":{
+                  "tool_id":"toolshed.g2.bx.psu.edu/repos/imgteam/2d_split_binaryimage_by_watershed/ip_2d_split_binaryimage_by_watershed/0.0.1",
+                  "tool_version":"0.0.1",
+                  "outputs":[
+                     {
+                        "type":"tiff",
+                        "name":"output"
+                     }
+                  ],
+                  "workflow_outputs":[
+
+                  ],
+                  "input_connections":{
+                     "input":{
+                        "output_name":"output",
+                        "id":3
+                     }
+                  },
+                  "tool_state":"{\"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"min_distance\": \"\\\"20\\\"\", \"__page__\": null}",
+                  "id":4,
+                  "tool_shed_repository":{
+                     "owner":"imgteam",
+                     "changeset_revision":"5e21d7342593",
+                     "name":"2d_split_binaryimage_by_watershed",
+                     "tool_shed":"toolshed.g2.bx.psu.edu"
+                  },
+                  "uuid":"8f69c8c6-106b-48ca-a31b-d0508dd10811",
+                  "errors":null,
+                  "name":"Split objects",
+                  "post_job_actions":{
+                     "HideDatasetActionoutput":{
+                        "output_name":"output",
+                        "action_type":"HideDatasetAction",
+                        "action_arguments":{
+
+                        }
+                     }
+                  },
+                  "label":null,
+                  "inputs":[
+                     {
+                        "name":"input",
+                        "description":"runtime parameter for tool Split objects"
+                     }
+                  ],
+                  "position":{
+                     "top":423,
+                     "left":611.5
+                  },
+                  "annotation":"",
+                  "content_id":"toolshed.g2.bx.psu.edu/repos/imgteam/2d_split_binaryimage_by_watershed/ip_2d_split_binaryimage_by_watershed/0.0.1",
+                  "type":"tool"
+               },
+               "5":{
+                  "tool_id":"toolshed.g2.bx.psu.edu/repos/imgteam/2d_feature_extraction/ip_2d_feature_extraction/0.1.1",
+                  "tool_version":"0.1.1",
+                  "outputs":[
+                     {
+                        "type":"tabular",
+                        "name":"output"
+                     }
+                  ],
+                  "workflow_outputs":[
+
+                  ],
+                  "input_connections":{
+                     "input_label":{
+                        "output_name":"output",
+                        "id":4
+                     }
+                  },
+                  "tool_state":"{\"input_label\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"use_raw_option\": \"{\\\"__current_case__\\\": 0, \\\"use_raw\\\": \\\"no_original\\\"}\", \"feature_options\": \"{\\\"__current_case__\\\": 1, \\\"features\\\": \\\"select\\\", \\\"selected_features\\\": [\\\"--label\\\", \\\"--area\\\", \\\"--eccentricity\\\", \\\"--major_axis_length\\\"]}\", \"__rerun_remap_job_id__\": null, \"__page__\": null}",
+                  "id":5,
+                  "tool_shed_repository":{
+                     "owner":"imgteam",
+                     "changeset_revision":"6fdb3542a406",
+                     "name":"2d_feature_extraction",
+                     "tool_shed":"toolshed.g2.bx.psu.edu"
+                  },
+                  "uuid":"4cfeb46f-0302-4ee7-8df3-e19789c39ca8",
+                  "errors":null,
+                  "name":"2D Feature Extraction",
+                  "post_job_actions":{
+                     "HideDatasetActionoutput":{
+                        "output_name":"output",
+                        "action_type":"HideDatasetAction",
+                        "action_arguments":{
+
+                        }
+                     }
+                  },
+                  "label":null,
+                  "inputs":[
+
+                  ],
+                  "position":{
+                     "top":367.1875,
+                     "left":857.5
+                  },
+                  "annotation":"",
+                  "content_id":"toolshed.g2.bx.psu.edu/repos/imgteam/2d_feature_extraction/ip_2d_feature_extraction/0.1.1",
+                  "type":"tool"
+               },
+               "6":{
+                  "tool_id":"toolshed.g2.bx.psu.edu/repos/imgteam/2d_filter_segmentation_by_features/ip_2d_filter_segmentation_by_features/0.0.1",
+                  "tool_version":"0.0.1",
+                  "outputs":[
+                     {
+                        "type":"tiff",
+                        "name":"output"
+                     }
+                  ],
+                  "workflow_outputs":[
+                     {
+                        "output_name":"output",
+                        "uuid":"65d3ad3d-90d3-4343-bb57-43a492bf4e7f",
+                        "label":null
+                     }
+                  ],
+                  "input_connections":{
+                     "input":{
+                        "output_name":"output",
+                        "id":4
+                     },
+                     "feature_file":{
+                        "output_name":"output",
+                        "id":5
+                     },
+                     "rule_file":{
+                        "output_name":"output",
+                        "id":1
+                     }
+                  },
+                  "tool_state":"{\"input\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"__rerun_remap_job_id__\": null, \"feature_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"rule_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"__page__\": null}",
+                  "id":6,
+                  "tool_shed_repository":{
+                     "owner":"imgteam",
+                     "changeset_revision":"e576b73a2e2f",
+                     "name":"2d_filter_segmentation_by_features",
+                     "tool_shed":"toolshed.g2.bx.psu.edu"
+                  },
+                  "uuid":"050edc66-f14f-4e24-9487-3a93c644c55c",
+                  "errors":null,
+                  "name":"Filter segmentation",
+                  "post_job_actions":{
+
+                  },
+                  "label":null,
+                  "inputs":[
+
+                  ],
+                  "position":{
+                     "top":512.1875,
+                     "left":1115.59375
+                  },
+                  "annotation":"",
+                  "content_id":"toolshed.g2.bx.psu.edu/repos/imgteam/2d_filter_segmentation_by_features/ip_2d_filter_segmentation_by_features/0.0.1",
+                  "type":"tool"
+               },
+               "7":{
+                  "tool_id":"toolshed.g2.bx.psu.edu/repos/imgteam/2d_feature_extraction/ip_2d_feature_extraction/0.1.1",
+                  "tool_version":"0.1.1",
+                  "outputs":[
+                     {
+                        "type":"tabular",
+                        "name":"output"
+                     }
+                  ],
+                  "workflow_outputs":[
+                     {
+                        "output_name":"output",
+                        "uuid":"db1d6547-ff56-4dc5-8437-1a9f866ff3a1",
+                        "label":null
+                     }
+                  ],
+                  "input_connections":{
+                     "input_label":{
+                        "output_name":"output",
+                        "id":6
+                     },
+                     "use_raw_option|input_raw":{
+                        "output_name":"output",
+                        "id":0
+                     }
+                  },
+                  "tool_state":"{\"input_label\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"use_raw_option\": \"{\\\"__current_case__\\\": 1, \\\"input_raw\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}, \\\"use_raw\\\": \\\"raw_image\\\"}\", \"feature_options\": \"{\\\"__current_case__\\\": 1, \\\"features\\\": \\\"select\\\", \\\"selected_features\\\": [\\\"--mean_intensity\\\", \\\"--area\\\", \\\"--major_axis_length\\\"]}\", \"__rerun_remap_job_id__\": null, \"__page__\": null}",
+                  "id":7,
+                  "tool_shed_repository":{
+                     "owner":"imgteam",
+                     "changeset_revision":"6fdb3542a406",
+                     "name":"2d_feature_extraction",
+                     "tool_shed":"toolshed.g2.bx.psu.edu"
+                  },
+                  "uuid":"7e1459ec-4dec-44d9-abae-2141194ad14c",
+                  "errors":null,
+                  "name":"2D Feature Extraction",
+                  "post_job_actions":{
+
+                  },
+                  "label":null,
+                  "inputs":[
+
+                  ],
+                  "position":{
+                     "top":664.796875,
+                     "left":1368
+                  },
+                  "annotation":"",
+                  "content_id":"toolshed.g2.bx.psu.edu/repos/imgteam/2d_feature_extraction/ip_2d_feature_extraction/0.1.1",
+                  "type":"tool"
+               }
+            },
+            "annotation":"",
+            "a_galaxy_workflow":"true"
+         },
+         "workflow_outputs":[
+            {
+               "output_name":"7:output",
+               "uuid":"b94ef03f-194e-4dc9-a088-436fe2b155c7",
+               "label":null
+            },
+            {
+               "output_name":"6:output",
+               "uuid":"89c6a772-67f6-4236-b753-ea7c657f758d",
+               "label":null
+            }
+         ],
+         "input_connections":{
+            "input image":{
+               "input_subworkflow_step_id":0,
+               "output_name":"unzipped",
+               "id":2
+            },
+            "filter rules":{
+               "input_subworkflow_step_id":1,
+               "output_name":"output",
+               "id":1
+            }
+         },
+         "id":3,
+         "uuid":"1519aa9a-7d3f-454c-b72f-c5a7ecb2e646",
+         "name":"feature_extraction",
+         "label":null,
+         "position":{
+            "top":421.3833312988281,
+            "left":782.8833312988281
+         },
+         "annotation":"",
+         "type":"subworkflow"
+      },
+      "4":{
+         "tool_id":"toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/4.0",
+         "tool_version":"4.0",
+         "outputs":[
+            {
+               "type":"input",
+               "name":"output"
+            }
+         ],
+         "workflow_outputs":[
+            {
+               "output_name":"output",
+               "uuid":"7f6e208f-1fc0-4e9e-a169-ddedaf1678d0",
+               "label": "outputs_collapsed"
+            }
+         ],
+         "input_connections":{
+            "input_list":{
+               "output_name":"7:output",
+               "id":3
+            }
+         },
+         "tool_state":"{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"input_list\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"one_header\": \"\\\"true\\\"\", \"filename\": \"{\\\"__current_case__\\\": 1, \\\"add_name\\\": \\\"false\\\"}\"}",
+         "id":4,
+         "tool_shed_repository":{
+            "owner":"nml",
+            "changeset_revision":"25136a2b0cfe",
+            "name":"collapse_collections",
+            "tool_shed":"toolshed.g2.bx.psu.edu"
+         },
+         "uuid":"a0d0dd96-ffce-4d84-87ee-1ee1c8b34f25",
+         "errors":null,
+         "name":"Collapse Collection",
+         "post_job_actions":{
+
+         },
+         "label":null,
+         "inputs":[
+
+         ],
+         "position":{
+            "top":526.8833312988281,
+            "left":1169.3833312988281
+         },
+         "annotation":"",
+         "content_id":"toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/4.0",
+         "type":"tool"
+      }
+   },
+   "annotation":"",
+   "a_galaxy_workflow":"true"
+}

--- a/imaging/rules.tabular
+++ b/imaging/rules.tabular
@@ -1,0 +1,3 @@
+	area	eccentricity
+min	500	0.
+max	100000	0.5


### PR DESCRIPTION
Run it with:

```console
planemo test --history_name "imaging" --galaxy_url https://usegalaxy.eu \
   --galaxy_user_key "$USEGALAXY_USER_KEY" --no_shed_install \
   --engine external_galaxy  imaging_many_jobs.ga 
```

@thomaswollmann this should work now and you can submit the workflow via CLI to Galaxy.

@jmchilton maybe this workflow is interesting for diverse benchmarks. It creates ~4000 jobs, all jobs process very fast. It stresses collections, job scheduling and metadata collection.