### PR TITLE
[WIP] test script and venv requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .venv/
 tool_test_output.*
+.secret.env

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+planemo==0.72.0
+galaxy-parsec==1.13.0

--- a/run_galaxy_workflow_tests.sh
+++ b/run_galaxy_workflow_tests.sh
@@ -14,6 +14,7 @@ planemo $PLANEMO_OPTIONS test \
 	--galaxy_user_key "$GALAXY_USER_KEY" \
 	--no_shed_install \
 	--engine external_galaxy \
+	--test_output_json test_output.json \
 	"$1";
 planemo_exit_code=$?
 set -e
@@ -26,6 +27,6 @@ else
 	# Otherwise immediately delete
 	history_id=$(parsec histories get_histories --name "$history_name" | jq -r .[0].id)
 	parsec histories delete_history --purge $history_id
-	echo "<html><head></head><body>Test was completely successful</body></html>"> history.html
+	echo "<html><head></head><body>Test was completely successful</body></html>" > history.html
 fi
 exit $planemo_exit_code

--- a/test_workflows.sh
+++ b/test_workflows.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# if GALAXY_URL and GALAXY_USER_KEY are not set, try to set them from local untracked file
+[ ! $GALAXY_URL ] || [ ! $GALAXY_USER_KEY ] && source .secret.env
+export GALAXY_URL GALAXY_USER_KEY
+
+virtualenv -p python3 .venv; . .venv/bin/activate
+pip install -r requirements.txt
+
+# initalise parsec with url and api key.  Remove any existing parsec configuration stored in the home directory
+rm -f ~/.parsec.yml ||:
+parsec init --url $GALAXY_URL --api_key $GALAXY_USER_KEY # caution: if ~/.parsec.yml already exists at this point it will not be updated
+
+workflow_list=workflows_to_test.txt
+# # get list of local workflows with tests (ignoring training folder)
+find . \( -name '*-test.yml' ! -path './training*' \) | sed 's/^\.\///g' | sed 's/-test.yml/.ga/g' > $workflow_list
+
+# # clone training-material repo
+git clone --depth 1 https://github.com/galaxyproject/training-material.git
+
+# # get list of training-material workflows with tests
+find 'training-material' -path '*-test.yml' | sed 's/-test.yml/.ga/g' >> $workflow_list
+
+[ -d test_output ] && rm -rf test_output
+mkdir test_output
+
+# run test for each workflow and store json report
+cat $workflow_list | while read line || [[ -n $line ]]; do
+   ./run_galaxy_workflow_tests.sh $line
+   mv test_output.json test_output/$(sed 's/\//__/g' <<< $line).test_output.json
+   mv history.html test_output/$(sed 's/\//__/g' <<< $line).history.html
+done
+
+# merge json reports and create html report from merged report
+find 'test_output' -name '*test_output.json' -exec sh -c 'planemo merge_test_reports "$@" test_output/merged_test_output.json' sh {} +
+planemo test_reports test_output/merged_test_output.json  --test_output merged_test_output.html
+


### PR DESCRIPTION
A script to clone training-material and find workflows with tests then run the tests + non-GTN-workflow tests in this repo.

The virtual environment requires planemo and parsec.  There is a conflict installing these requirements and it ends up using bioblend version 0.14.0 which is too new for parsec,  but this seems to be fine for the parsec calls used in the script.

@bgruening what code is on Jenkins for this currently?  I'd like to make the history.html links and the planemo reports available after the test run.  The planemo report is useful if the test has failed because of tool versions, history links are useful for just about everything else.

TODO: Makefile, automatic updating of the readme