### PR TITLE
Add new example workflow

### DIFF
--- a/example3/data/dataset1.txt
+++ b/example3/data/dataset1.txt
@@ -1,0 +1,2 @@
+hello
+world

--- a/example3/data/dataset2.txt
+++ b/example3/data/dataset2.txt
@@ -1,0 +1,3 @@
+this
+is
+dataset 2

--- a/example3/data/output.txt
+++ b/example3/data/output.txt
@@ -1,0 +1,3 @@
+is
+hello
+world

--- a/example3/tutorial-job.yml
+++ b/example3/tutorial-job.yml
@@ -1,0 +1,7 @@
+Dataset 1:
+  class: File
+  path: "data/dataset1.txt"
+Dataset 2:
+  class: File
+  path: "data/dataset2.txt"
+Number of lines: 3

--- a/example3/tutorial-tests.yml
+++ b/example3/tutorial-tests.yml
@@ -1,0 +1,13 @@
+- doc: Test outline for tutorial.ga
+  job:
+    Dataset 1:
+      class: File
+      path: "data/dataset1.txt"
+    Dataset 2:
+      class: File
+      path: "data/dataset2.txt"
+    Number of lines: 3
+  outputs:
+    output:
+      class: File
+      path: "data/output.txt"

--- a/example3/tutorial.ga
+++ b/example3/tutorial.ga
@@ -205,7 +205,15 @@
                 "x": 904.5,
                 "y": 320
             },
-            "post_job_actions": {},
+            "post_job_actions": {
+                "RenameDatasetActionout_file1": {
+                    "action_arguments": {
+                        "newname": "tutorial_output.txt"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
             "tool_id": "random_lines1",
             "tool_state": "{\"input\": {\"__class__\": \"RuntimeValue\"}, \"num_lines\": {\"__class__\": \"ConnectedValue\"}, \"seed_source\": {\"seed_source_selector\": \"set_seed\", \"__current_case__\": 1, \"seed\": \"0\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.0.2",

--- a/example3/tutorial.ga
+++ b/example3/tutorial.ga
@@ -1,0 +1,226 @@
+{
+    "a_galaxy_workflow": "true",
+    "annotation": "",
+    "format-version": "0.1",
+    "name": "planemo run tutorial",
+    "steps": {
+        "0": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Dataset 2"
+                }
+            ],
+            "label": "Dataset 2",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 355.8000030517578,
+                "height": 61.80000305175781,
+                "left": 348.5,
+                "right": 548.5,
+                "top": 294,
+                "width": 200,
+                "x": 348.5,
+                "y": 294
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "004a6ce7-a8f3-4a54-b513-e1456a3695e8",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "05042d8c-8f06-4646-81ba-1f4ffb858ad3"
+                }
+            ]
+        },
+        "1": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 1,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Dataset 1"
+                }
+            ],
+            "label": "Dataset 1",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 455.8000030517578,
+                "height": 61.80000305175781,
+                "left": 348.5,
+                "right": 548.5,
+                "top": 394,
+                "width": 200,
+                "x": 348.5,
+                "y": 394
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "b42b2137-033e-4e7e-849e-21def05f4a70",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "8c0a8c18-74d3-43c5-b3fa-8d1a3a4721b6"
+                }
+            ]
+        },
+        "2": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 2,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Number of lines"
+                }
+            ],
+            "label": "Number of lines",
+            "name": "Input parameter",
+            "outputs": [],
+            "position": {
+                "bottom": 544.1999969482422,
+                "height": 82.19999694824219,
+                "left": 626.5,
+                "right": 826.5,
+                "top": 462,
+                "width": 200,
+                "x": 626.5,
+                "y": 462
+            },
+            "tool_id": null,
+            "tool_state": "{\"parameter_type\": \"integer\", \"optional\": false}",
+            "tool_version": null,
+            "type": "parameter_input",
+            "uuid": "442ca31b-cdcf-46eb-815c-c23baf2c4dc5",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "f47aa63e-c347-4e2b-9b9e-c95c2e7df101"
+                }
+            ]
+        },
+        "3": {
+            "annotation": "",
+            "content_id": "cat1",
+            "errors": null,
+            "id": 3,
+            "input_connections": {
+                "input1": {
+                    "id": 0,
+                    "output_name": "output"
+                },
+                "queries_0|input2": {
+                    "id": 1,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Concatenate datasets",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "bottom": 424,
+                "height": 144,
+                "left": 626.5,
+                "right": 826.5,
+                "top": 280,
+                "width": 200,
+                "x": 626.5,
+                "y": 280
+            },
+            "post_job_actions": {},
+            "tool_id": "cat1",
+            "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"queries\": [{\"__index__\": 0, \"input2\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "860edbb3-b1dd-42a0-8edd-d4d3838ca916",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "out_file1",
+                    "uuid": "ca8c4181-931d-4ff2-98ae-19d9316f9fa4"
+                }
+            ]
+        },
+        "4": {
+            "annotation": "",
+            "content_id": "random_lines1",
+            "errors": null,
+            "id": 4,
+            "input_connections": {
+                "input": {
+                    "id": 3,
+                    "output_name": "out_file1"
+                },
+                "num_lines": {
+                    "id": 2,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Select random lines",
+                    "name": "input"
+                }
+            ],
+            "label": null,
+            "name": "Select random lines",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "bottom": 464,
+                "height": 144,
+                "left": 904.5,
+                "right": 1104.5,
+                "top": 320,
+                "width": 200,
+                "x": 904.5,
+                "y": 320
+            },
+            "post_job_actions": {},
+            "tool_id": "random_lines1",
+            "tool_state": "{\"input\": {\"__class__\": \"RuntimeValue\"}, \"num_lines\": {\"__class__\": \"ConnectedValue\"}, \"seed_source\": {\"seed_source_selector\": \"set_seed\", \"__current_case__\": 1, \"seed\": \"0\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.0.2",
+            "type": "tool",
+            "uuid": "2f32db91-1fdb-4a61-97e9-6aa3a63e45e2",
+            "workflow_outputs": [
+                {
+                    "label": "output",
+                    "output_name": "out_file1",
+                    "uuid": "22c0a13c-4aed-4874-a742-6753a77c505a"
+                }
+            ]
+        }
+    },
+    "tags": [],
+    "uuid": "9ef02c65-d5b0-4380-8eac-567585f21a07",
+    "version": 2
+}


### PR DESCRIPTION
I'd like to add a new example workflow for the WIP planemo tutorial here: https://github.com/galaxyproject/planemo/pull/1102 - I hope that's okay? This one contains only tools which are installed by default on Galaxy instances and also has an example of an input param as well as input datasets.